### PR TITLE
[FRONT-END & BACK-END] Added ability for managers to create collections and added technicians board

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -15,3 +15,7 @@ class User(AbstractUser):
     
     def __str__(self):
         return f"{self.first_name} {self.last_name} ({self.role})"
+
+
+class FaultCase:
+    pass

--- a/accounts/templates/accounts/create_collection.html
+++ b/accounts/templates/accounts/create_collection.html
@@ -1,0 +1,26 @@
+{% extends 'accounts/dashboard_base.html' %}
+
+{% block dashboard_title %}Create New Location{% endblock %}
+
+{% block dashboard_content %}
+<div class="card">
+    <div class="card-header bg-dark text-white">
+        <h5 class="mb-0">Add New Location</h5>
+    </div>
+    <div class="card-body">
+        <form method="POST">
+            {% csrf_token %}
+            <div class="mb-3">
+                <label for="name" class="form-label">Location Name</label>
+                <input type="text" name="name" id="name" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="description" class="form-label">Description</label>
+                <textarea name="description" id="description" class="form-control" rows="3"></textarea>
+            </div>
+            <button type="submit" class="btn btn-success">Create</button>
+            <a href="{% url 'accounts:manager_dashboard' %}" class="btn btn-secondary">Cancel</a>
+        </form>
+    </div>
+</div>
+{% endblock %}

--- a/accounts/templates/accounts/create_machinery.html
+++ b/accounts/templates/accounts/create_machinery.html
@@ -77,17 +77,31 @@
                     </select>
                 </div>
 
-                <!-- Assign technician here -->
-                <div class="mb-4">
-                    <label for="assigned_to" class="form-label">Assign to Technician:</label>
-                    <select name="assigned_to" class="form-select">
-                        <option value="">-- None --</option>
-                        {% for tech in technicians %}
-                            <option value="{{ tech.id }}">{{ tech.get_full_name }}</option>
+                <!-- Assign Technician -->
+                <div class="mb-3">
+                    <label for="assigned_technician" class="form-label">Assign Technician:</label>
+                    <select name="assigned_technician" class="form-select">
+                        <option value="">— Select Technician —</option>
+                        {% for user in staff %}
+                            {% if user.role == "TECHNICIAN" %}
+                                <option value="{{ user.id }}">{{ user.get_full_name }}</option>
+                            {% endif %}
                         {% endfor %}
                     </select>
                 </div>
 
+                <!-- Assign Repair Staff -->
+                <div class="mb-3">
+                    <label for="assigned_repair" class="form-label">Assign Repair Person:</label>
+                    <select name="assigned_repair" class="form-select">
+                        <option value="">— Select Repair Staff —</option>
+                        {% for user in staff %}
+                            {% if user.role == "REPAIR" %}
+                                <option value="{{ user.id }}">{{ user.get_full_name }}</option>
+                            {% endif %}
+                        {% endfor %}
+                    </select>
+                </div>
                 <button type="submit" class="btn btn-primary w-100">Add Machine</button>
             </form>
         </div>

--- a/accounts/templates/accounts/manager_dashboard.html
+++ b/accounts/templates/accounts/manager_dashboard.html
@@ -91,8 +91,13 @@
     <div class="row mb-4">
         <div class="col-12">
             <div class="d-flex gap-2">
+                <!-- Add machine -->
                 <a href="{% url 'accounts:create_machines' %}" class="btn btn-primary">
                     <i class="bi bi-plus-circle"></i> Add Machine
+                </a>
+                <!-- Add collection -->
+                <a href="{% url 'accounts:create_collection' %}" class="btn btn-outline-dark">
+                    <i class="bi bi-folder-plus"></i> Add Collection
                 </a>
                 <button class="btn btn-secondary"><i class="bi bi-gear"></i> System Settings</button>
             </div>
@@ -221,6 +226,78 @@
                     <li class="page-item"><a class="page-link" href="#">Next</a></li>
                 </ul>
             </nav>
+        </div>
+    </div>
+
+    <!-- Collections -->
+    <!-- Location Overview Table -->
+    <div class="card mt-5">
+        <div class="card-header bg-dark text-white">
+            <h5 class="mb-0">Collections & Assigned Machinery</h5>
+        </div>
+        <div class="card-body">
+            {% if collection_summaries %}
+            <div class="table-responsive">
+                <table class="table table-striped align-middle">
+                    <thead class="table-secondary">
+                        <tr>
+                            <th>#</th>
+                            <th>Collection Name</th>
+                            <th>Description</th>
+                            <th>Machines Assigned</th>
+                            <th>Actions</th>
+                            <th>Export</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for col in collection_summaries %}
+                        <tr>
+                            <td>{{ forloop.counter }}</td>
+                            <td><strong>{{ col.name }}</strong></td>
+                            <td class="text-muted">{{ col.description|default:"—" }}</td>
+                            <td>
+                                {% if col.machines %}
+                                    <ul class="list-unstyled mb-0">
+                                        {% for machine in col.machines %}
+                                            <li>{{ machine.name }} <span class="text-muted">({{ machine.status }})</span></li>
+                                        {% endfor %}
+                                    </ul>
+                                {% else %}
+                                    <span class="text-muted">No machines</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                <div class="btn-group">
+                                    <!-- Confirm if really want to delete -->
+                                    <a href="{% url 'accounts:delete_collection' col.id %}" class="btn btn-sm btn-danger"
+                                       onclick="return confirm('Are you sure you want to delete this collection?');">
+                                        <i class="bi bi-x-circle"></i> Delete
+                                    </a>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="dropdown">
+                                    <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                        Export
+                                    </button>
+                                    <ul class="dropdown-menu">
+                                        <li>
+                                            <a class="dropdown-item" href="{% url 'accounts:export_machines_by_collection' col.id %}">
+                                                By Collection
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                            </td>
+
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+            {% else %}
+                <p class="text-muted">No locations found.</p>
+            {% endif %}
         </div>
     </div>
 

--- a/accounts/templates/accounts/manager_dashboard.html
+++ b/accounts/templates/accounts/manager_dashboard.html
@@ -187,8 +187,8 @@
                                         </a>
                                     </div>
                                 </td>
-                                <td>
-                                    <div class="dropdown">
+                                <td class="export-column">
+                                    <div class="dropdown export-dropdown">
                                         <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
                                             Export
                                         </button>

--- a/accounts/templates/accounts/repair_dashboard.html
+++ b/accounts/templates/accounts/repair_dashboard.html
@@ -81,10 +81,10 @@
                             <label class="form-label">Parts Used</label>
                             <textarea class="form-control" id="partsUsed" name="partsUsed" rows="2" placeholder="List parts used"></textarea>
                         </div>
-                        
+
                         <!-- Container for previous notes -->
                         <div id="previousNotesContainer"></div>
-                        
+
                         <div class="mb-3">
                             <label class="form-label">Add New Note</label>
                             <textarea class="form-control" id="repairNotes" name="repairNotes" rows="3" placeholder="Enter new repair notes"></textarea>
@@ -102,7 +102,7 @@
             </div>
         </div>
     </div>
-    
+
     <!-- Machine Details Modal -->
     <div class="modal fade" id="machineDetailsModal" tabindex="-1">
         <div class="modal-dialog modal-lg">
@@ -152,7 +152,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <h5>Repair History</h5>
                     <div id="repairs-list">
                         <p class="text-center">
@@ -178,17 +178,17 @@
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
         cursor: pointer;
     }
-    
+
     .status-card:hover {
         transform: translateY(-5px);
         box-shadow: 0 8px 15px rgba(0, 0, 0, 0.2);
     }
-    
+
     /* Add a subtle pulse effect to highlight active card */
     .status-card.active {
         animation: pulse 2s infinite;
     }
-    
+
     @keyframes pulse {
         0% {
             box-shadow: 0 0 0 0 rgba(255, 255, 255, 0.7);
@@ -200,16 +200,16 @@
             box-shadow: 0 0 0 0 rgba(255, 255, 255, 0);
         }
     }
-    
+
     /* Card specific styles */
     .open-card {
         background-color: rgba(220, 53, 69, 0.1);
     }
-    
+
     .in-progress-card {
         background-color: rgba(255, 193, 7, 0.1);
     }
-    
+
     .resolved-card {
         background-color: rgba(40, 167, 69, 0.1);
     }

--- a/accounts/templates/accounts/technician_dashboard.html
+++ b/accounts/templates/accounts/technician_dashboard.html
@@ -1,4 +1,5 @@
 {% extends 'accounts/dashboard_base.html' %}
+{% load custom_filters %}
 
 {% block title %}Technician Dashboard - Factory Machinery Status & Repair Tracking{% endblock %}
 
@@ -12,96 +13,119 @@
 {% endblock %}
 
 {% block dashboard_content %}
-    <p>You are responsible for monitoring machinery, maintaining records, and coordination with repair personnel.</p>
+<p>You are responsible for monitoring machinery, maintaining records, and coordinating with repair personnel.</p>
 
-    <!-- Assigned Machines Table -->
-    <div class="card mb-4">
-        <div class="card-header bg-primary text-white">
+<!-- Assigned or All Machines -->
+<div class="card mb-4">
+    <div class="card-header bg-primary text-white">
+        {% if fallback_used %}
+            No machines assigned — showing all available machinery
+        {% else %}
             My Assigned Machines
-        </div>
-        <div class="card-body">
-            <div class="table-responsive">
-                <table class="table table-striped align-middle">
-                    <thead class="table-dark">
-                        <tr>
-                            <th>Machine ID</th>
-                            <th>Name</th>
-                            <th>Location</th>
-                            <th>Status</th>
-                            <th>Last Check</th>
-                            <th>Actions</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>FM-101</td>
-                            <td>Hydraulic Press</td>
-                            <td>Building 1</td>
-                            <td><span class="badge bg-success">Operational</span></td>
-                            <td>2025-04-01</td>
-                            <td>
-                                <button class="btn btn-sm btn-warning">Add Warning</button>
-                                <button class="btn btn-sm btn-danger">Report Fault</button>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>FM-102</td>
-                            <td>Assembly Line Robot</td>
-                            <td>Building 2</td>
-                            <td><span class="badge bg-warning text-dark">Warning</span></td>
-                            <td>2025-04-05</td>
-                            <td>
-                                <button class="btn btn-sm btn-warning">Add Warning</button>
-                                <button class="btn btn-sm btn-danger">Report Fault</button>
-                            </td>
-                        </tr>
-                        <tr>
-                            <td>FM-104</td>
-                            <td>Packaging Machine</td>
-                            <td>Building 3</td>
-                            <td><span class="badge bg-success">Operational</span></td>
-                            <td>2025-04-07</td>
-                            <td>
-                                <button class="btn btn-sm btn-warning">Add Warning</button>
-                                <button class="btn btn-sm btn-danger">Report Fault</button>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-        </div>
+        {% endif %}
     </div>
+    <div class="card-body">
+        {% if assigned_machines %}
+        <div class="table-responsive">
+            <table class="table table-striped align-middle">
+                <thead class="table-dark">
+                    <tr>
+                        <th>Machine ID</th>
+                        <th>Name</th>
+                        <th>Location</th>
+                        <th>Status</th>
+                        <th>Priority</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for machine in assigned_machines %}
+                    <tr>
+                        <td>{{ machine.machine_id }}</td>
+                        <td>{{ machine.name }}</td>
+                        <td>
+                            {% for mc in machine.machinerycollection_set.all %}
+                                {{ mc.collection.name }}{% if not forloop.last %}, {% endif %}
+                            {% empty %}—
+                            {% endfor %}
+                        </td>
+                        <td>
+                            {% if machine.status == "OK" %}
+                                <span class="badge bg-success">OK</span>
+                            {% elif machine.status == "WARNING" %}
+                                <span class="badge bg-warning text-dark">Warning</span>
+                            {% elif machine.status == "FAULT" %}
+                                <span class="badge bg-danger">Fault</span>
+                            {% else %}
+                                <span class="badge bg-secondary">Unknown</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            {% if machine.priority >= 7 %}
+                                <span class="badge bg-danger">High</span>
+                            {% elif machine.priority >= 4 %}
+                                <span class="badge bg-warning text-dark">Medium</span>
+                            {% else %}
+                                <span class="badge bg-secondary">Low</span>
+                            {% endif %}
+                        </td>
+                        <td>
+                            <button class="btn btn-sm btn-warning">Add Warning</button>
 
-    <!-- Upload Notes/Images -->
-    <div class="card mb-4">
-        <div class="card-header bg-info text-white">
-            Upload Notes/Images
+                            {% if machine.status != "FAULT" %}
+                                <a href="{% url 'repairs:fault_case_create' %}" class="btn btn-sm btn-danger">Report Fault</a>
+                            {% endif %}
+
+                            {% with fault_cases|get_item:machine.machine_id as case_id %}
+                                {% if machine.status != "OK" and case_id %}
+                                    <a href="{% url 'repairs:fault_case_detail' case_id %}" class="btn btn-sm btn-success">
+                                        View Fault
+                                    </a>
+                                {% elif not case_id %}
+                                    <span class="text-muted">No Fault</span>
+                                {% endif %}
+                            {% endwith %}
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
-        <div class="card-body">
-            <form>
-                <div class="mb-3">
-                    <label class="form-label">Machine ID</label>
-                    <select class="form-select">
-                        <option>Select Machine</option>
-                        <option>FM-101</option>
-                        <option>FM-102</option>
-                        <option>FM-104</option>
-                    </select>
-                </div>
-                <div class="mb-3">
-                    <label class="form-label">Notes</label>
-                    <textarea class="form-control" rows="3" placeholder="Enter your maintenance notes"></textarea>
-                </div>
-                <div class="mb-3">
-                    <label class="form-label">Upload Images</label>
-                    <input class="form-control" type="file" multiple>
-                </div>
-                <button class="btn btn-primary">Submit</button>
-            </form>
-        </div>
+        {% else %}
+        <div class="alert alert-info">No machines available to show at this time.</div>
+        {% endif %}
     </div>
+</div>
+
+<!-- Upload Notes/Images -->
+<div class="card mb-4">
+    <div class="card-header bg-info text-white">
+        Upload Notes/Images
+    </div>
+    <div class="card-body">
+        <form>
+            <div class="mb-3">
+                <label class="form-label">Machine</label>
+                <select class="form-select" required>
+                    <option selected disabled>Select Machine</option>
+                    {% for machine in assigned_machines %}
+                        <option value="{{ machine.machine_id }}">{{ machine.name }} ({{ machine.model|default:"No Model" }})</option>
+                    {% endfor %}
+                </select>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Notes</label>
+                <textarea class="form-control" rows="3" placeholder="Enter your maintenance notes"></textarea>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Upload Images</label>
+                <input class="form-control" type="file" multiple>
+            </div>
+            <button class="btn btn-primary">Submit</button>
+        </form>
+    </div>
+</div>
 {% endblock %}
 
 {% block extra_js %}
-<!-- Additional JavaScript specific to technician dashboard can go here -->
 {% endblock %}

--- a/accounts/templates/accounts/technician_dashboard.html
+++ b/accounts/templates/accounts/technician_dashboard.html
@@ -70,8 +70,7 @@
                             {% endif %}
                         </td>
                         <td>
-                            <button class="btn btn-sm btn-warning">Add Warning</button>
-
+                            <!-- <a href="{#% url 'repairs:warning_form' machine.machine_id %#}" class="btn btn-sm btn-warning">Add Warning</a> -->
                             {% if machine.status != "FAULT" %}
                                 <a href="{% url 'repairs:fault_case_create' %}" class="btn btn-sm btn-danger">Report Fault</a>
                             {% endif %}
@@ -94,35 +93,6 @@
         {% else %}
         <div class="alert alert-info">No machines available to show at this time.</div>
         {% endif %}
-    </div>
-</div>
-
-<!-- Upload Notes/Images -->
-<div class="card mb-4">
-    <div class="card-header bg-info text-white">
-        Upload Notes/Images
-    </div>
-    <div class="card-body">
-        <form>
-            <div class="mb-3">
-                <label class="form-label">Machine</label>
-                <select class="form-select" required>
-                    <option selected disabled>Select Machine</option>
-                    {% for machine in assigned_machines %}
-                        <option value="{{ machine.machine_id }}">{{ machine.name }} ({{ machine.model|default:"No Model" }})</option>
-                    {% endfor %}
-                </select>
-            </div>
-            <div class="mb-3">
-                <label class="form-label">Notes</label>
-                <textarea class="form-control" rows="3" placeholder="Enter your maintenance notes"></textarea>
-            </div>
-            <div class="mb-3">
-                <label class="form-label">Upload Images</label>
-                <input class="form-control" type="file" multiple>
-            </div>
-            <button class="btn btn-primary">Submit</button>
-        </form>
     </div>
 </div>
 {% endblock %}

--- a/accounts/templates/accounts/update_machinery.html
+++ b/accounts/templates/accounts/update_machinery.html
@@ -83,20 +83,47 @@
                     </select>
                 </div>
 
+                <!-- Assign Technician -->
                 <div class="mb-4">
-                    <label for="assigned_to" class="form-label">Assign Technician</label>
-                    <select name="assigned_to" class="form-select">
-                        <option value="">-- None --</option>
-                        {% for tech in technicians %}
-                            <option value="{{ tech.id }}"
-                                {% if assignments and assignments.0.assigned_to.id == tech.id %}
-                                    selected
-                                {% endif %}
-                            >{{ tech.get_full_name }}</option>
+                    <label for="assigned_technician" class="form-label">Assign Technician</label>
+                    <select name="assigned_technician" class="form-select">
+                        <option value="">— Select Technician —</option>
+                        {% for user in staff %}
+                            {% if user.role == "TECHNICIAN" %}
+                                <option value="{{ user.id }}"
+                                    {% for a in machine.machineryassignment_set.all %}
+                                        {% if a.assigned_to.id == user.id and a.is_active and a.assigned_to.role == "TECHNICIAN" %}
+                                            selected
+                                        {% endif %}
+                                    {% endfor %}
+                                >
+                                    {{ user.get_full_name }}
+                                </option>
+                            {% endif %}
                         {% endfor %}
                     </select>
                 </div>
 
+                <!-- Assign Repair Staff -->
+                <div class="mb-4">
+                    <label for="assigned_repair" class="form-label">Assign Repair Staff</label>
+                    <select name="assigned_repair" class="form-select">
+                        <option value="">— Select Repair Staff —</option>
+                        {% for user in staff %}
+                            {% if user.role == "REPAIR" %}
+                                <option value="{{ user.id }}"
+                                    {% for a in machine.machineryassignment_set.all %}
+                                        {% if a.assigned_to.id == user.id and a.is_active and a.assigned_to.role == "REPAIR" %}
+                                            selected
+                                        {% endif %}
+                                    {% endfor %}
+                                >
+                                    {{ user.get_full_name }}
+                                </option>
+                            {% endif %}
+                        {% endfor %}
+                    </select>
+                </div>
                 <button type="submit" class="btn btn-primary w-100">Update Machine</button>
             </form>
         </div>

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -33,4 +33,9 @@ urlpatterns = [
     path('dashboard/manager/machines/<int:machine_id>/delete/', views.delete_machine, name='delete_machine'),
     path('dashboard/manager/machines/<int:machine_id>/export/', views.export_machine_by_id, name='export_machine_by_id'),
     path('dashboard/manager/collections/<int:collection_id>/export/', views.export_machines_by_collection, name='export_machines_by_collection'),
+
+    path('dashboard/manager/collections/create/', views.create_collection, name='create_collection'),
+    path('dashboard/manager/collections/<int:collection_id>/delete/', views.delete_collection, name='delete_collection'),
+
+
 ]

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -36,6 +36,4 @@ urlpatterns = [
 
     path('dashboard/manager/collections/create/', views.create_collection, name='create_collection'),
     path('dashboard/manager/collections/<int:collection_id>/delete/', views.delete_collection, name='delete_collection'),
-
-
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -9,7 +9,7 @@ from rest_framework.decorators import api_view, permission_classes
 from machinery.models import Machinery, MachineryAssignment, Collection, MachineryCollection
 from .serializers import UserSerializer
 from .models import User
-from repairs.models import FaultCase
+from repairs.models import FaultCase, Warning
 import json
 from django.views.decorators.csrf import csrf_exempt
 from rest_framework.permissions import AllowAny

--- a/core/static/Javascript/manager_dashboard.js
+++ b/core/static/Javascript/manager_dashboard.js
@@ -2,28 +2,28 @@ document.addEventListener('DOMContentLoaded', function() {
     // Initialize modals
     const machineDetailsModal = new bootstrap.Modal(document.getElementById('machineDetailsModal'));
     const repairModal = new bootstrap.Modal(document.getElementById('repairModal'));
-    
+
     // Store current machine ID and repair ID
     let currentMachineId = null;
     let currentRepairId = null;
     let previouslyFocusedElement = null;
     let currentStatusFilter = 'ALL'; // Track current filter status
-    
+
     // Start real-time updates for count cards
     startRealTimeUpdates();
-    
+
     // Set up event listeners
     initEventListeners();
-    
+
     // Function to start periodic updates of count cards
     function startRealTimeUpdates() {
         // Fetch counts immediately on page load
         fetchMachineCounts();
-        
+
         // Then fetch counts every 30 seconds
         setInterval(fetchMachineCounts, 30000);
     }
-    
+
     // Function to fetch machine counts from the server
     function fetchMachineCounts() {
         fetch('/api/machinery/counts/', {
@@ -51,51 +51,63 @@ document.addEventListener('DOMContentLoaded', function() {
             console.error('Error fetching machine counts:', error);
         });
     }
-    
+
     function initEventListeners() {
         // Handle status card clicks for filtering
         document.querySelectorAll('.status-card').forEach(card => {
             card.addEventListener('click', function() {
                 const status = this.dataset.status;
                 currentStatusFilter = status;
-                
+
                 // Highlight the selected card
                 document.querySelectorAll('.status-card').forEach(c => {
                     c.classList.remove('border-5', 'border-white', 'active');
                 });
                 this.classList.add('border-5', 'border-white', 'active');
-                
+
                 // Filter table based on status
                 filterMachineTable(status);
             });
         });
-        
-        // Handle machine row clicks
+
+        // Make only machine names clickable for details modal
         document.querySelectorAll('.machine-row').forEach(row => {
-            row.addEventListener('click', function() {
-                const machineId = this.dataset.machineId;
-                currentMachineId = machineId;
-                loadMachineDetails(machineId);
-                machineDetailsModal.show();
-            });
+            // Remove the pointer cursor from the entire row
+            row.style.cursor = 'default';
+
+            // Get the name cell (second column) in this row
+            const nameCell = row.querySelector('td:nth-child(2)');
+
+            // Only add click handler to the name cell
+            if (nameCell) {
+                nameCell.style.cursor = 'pointer'; // Add pointer cursor to name cell only
+                nameCell.classList.add('text-primary'); // Mmake name look clickable
+
+                nameCell.addEventListener('click', function() {
+                    const machineId = row.dataset.machineId;
+                    currentMachineId = machineId;
+                    loadMachineDetails(machineId);
+                    machineDetailsModal.show();
+                });
+            }
         });
-        
+
         // Handle direct history button clicks in the table
         document.querySelectorAll('.view-history-btn').forEach(btn => {
             btn.addEventListener('click', function(e) {
-                // Stop the event from bubbling up to the row click handler
+                // Stop the event from bubbling up
                 e.stopPropagation();
-                
+
                 const machineId = this.dataset.machineId;
                 currentMachineId = machineId;
-                
+
                 // Reset the repair notes content
                 document.getElementById('repairNotesContent').innerHTML = `
                     <div class="text-center py-5">
                         <p class="text-muted">Select a repair from the history tab to view its notes</p>
                     </div>
                 `;
-                
+
                 // Show history tab and load repair history
                 const historyTab = document.querySelector('#history-tab');
                 historyTab.click();
@@ -103,7 +115,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 repairModal.show();
             });
         });
-        
+
         // Handle view repair history button in details modal
         const viewRepairHistoryBtn = document.getElementById('viewRepairHistoryBtn');
         if (viewRepairHistoryBtn) {
@@ -115,7 +127,7 @@ document.addEventListener('DOMContentLoaded', function() {
                             <p class="text-muted">Select a repair from the history tab to view its notes</p>
                         </div>
                     `;
-                    
+
                     // Show history tab and load repair history
                     const historyTab = document.querySelector('#history-tab');
                     historyTab.click();
@@ -124,7 +136,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             });
         }
-        
+
         // Handle edit machine button
         const editMachineBtn = document.getElementById('editMachineBtn');
         if (editMachineBtn) {
@@ -134,13 +146,13 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
             });
         }
-        
+
         // Handle modal hidden events to maintain filter state
         const modalElements = [
             document.getElementById('machineDetailsModal'),
             document.getElementById('repairModal')
         ];
-        
+
         modalElements.forEach(modalElement => {
             if (modalElement) {
                 modalElement.addEventListener('hidden.bs.modal', function() {
@@ -151,25 +163,25 @@ document.addEventListener('DOMContentLoaded', function() {
                 });
             }
         });
-        
+
         // Improved modal accessibility fixes
         setupModalAccessibility();
     }
-    
+
     // Function to filter the machine table based on status
     function filterMachineTable(status) {
         const machineRows = document.querySelectorAll('.machine-row');
         const tableContainer = document.querySelector('.card-body .table-responsive');
-        
+
         let visibleCount = 0;
-        
+
         machineRows.forEach(row => {
             // Find the status badge inside the row
             const statusBadge = row.querySelector('td:nth-child(5) .badge');
             if (!statusBadge) return;
-            
+
             const machineStatus = statusBadge.textContent.trim().toUpperCase();
-            
+
             if (status === 'ALL' || machineStatus === status) {
                 row.style.display = '';
                 visibleCount++;
@@ -177,7 +189,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 row.style.display = 'none';
             }
         });
-        
+
         // Update the table header to show what we're filtering by
         const tableHeader = document.querySelector('.card-header span');
         if (tableHeader) {
@@ -187,19 +199,19 @@ document.addEventListener('DOMContentLoaded', function() {
                 tableHeader.textContent = `Machinery Status (${status.charAt(0) + status.slice(1).toLowerCase()} Only)`;
             }
         }
-        
+
         // Show a message if no results
         if (visibleCount === 0 && tableContainer) {
             // Check if we already have a "no results" message
             let noResultsMsg = tableContainer.querySelector('.no-results-message');
-            
+
             if (!noResultsMsg) {
                 // Create the message if it doesn't exist
                 noResultsMsg = document.createElement('div');
                 noResultsMsg.className = 'alert alert-info no-results-message mt-3';
                 tableContainer.appendChild(noResultsMsg);
             }
-            
+
             noResultsMsg.textContent = `No machines with ${status.toLowerCase()} status found.`;
             noResultsMsg.style.display = 'block';
         } else if (tableContainer) {
@@ -210,7 +222,7 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         }
     }
-    
+
     function setupModalAccessibility() {
         // Accessibility fix for the machineDetailsModal
         const machineDetailsModalElement = document.getElementById('machineDetailsModal');
@@ -218,14 +230,14 @@ document.addEventListener('DOMContentLoaded', function() {
             machineDetailsModalElement.addEventListener('show.bs.modal', function() {
                 previouslyFocusedElement = document.activeElement;
             });
-            
+
             machineDetailsModalElement.addEventListener('hide.bs.modal', function(event) {
                 this.setAttribute('inert', '');
-                
+
                 this.addEventListener('hidden.bs.modal', function onHidden() {
                     this.removeAttribute('inert');
                     this.removeEventListener('hidden.bs.modal', onHidden);
-                    
+
                     if (previouslyFocusedElement && previouslyFocusedElement.focus) {
                         try {
                             previouslyFocusedElement.focus();
@@ -238,7 +250,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 }, { once: true });
             });
         }
-        
+
         // Similar handling for repairModal
         const repairModalElement = document.getElementById('repairModal');
         if (repairModalElement) {
@@ -251,12 +263,12 @@ document.addEventListener('DOMContentLoaded', function() {
             });
         }
     }
-    
+
     // Function to load machine details
     function loadMachineDetails(machineId) {
         const detailsContainer = document.getElementById('machineDetailsContent');
         if (!detailsContainer) return;
-        
+
         detailsContainer.innerHTML = `
             <div class="text-center">
                 <div class="spinner-border text-primary" role="status">
@@ -264,7 +276,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
             </div>
         `;
-        
+
         // Fetch machine details from server
         fetch(`/api/machinery/${machineId}/details/`, {
             headers: {
@@ -317,12 +329,12 @@ document.addEventListener('DOMContentLoaded', function() {
             `;
         });
     }
-    
+
     // Function to load repair history
     function loadRepairHistory(machineId) {
         const historyContainer = document.getElementById('repairHistoryContent');
         if (!historyContainer) return;
-        
+
         historyContainer.innerHTML = `
             <div class="text-center">
                 <div class="spinner-border text-primary" role="status">
@@ -330,7 +342,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
             </div>
         `;
-        
+
         // Fetch repair history from server
         fetch(`/api/machinery/${machineId}/repairs/`, {
             headers: {
@@ -355,7 +367,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 `;
                 return;
             }
-            
+
             // Create table with repair history
             let tableHtml = `
                 <table class="table table-striped">
@@ -372,7 +384,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </thead>
                     <tbody>
             `;
-            
+
             repairs.forEach(repair => {
                 tableHtml += `
                     <tr>
@@ -390,21 +402,21 @@ document.addEventListener('DOMContentLoaded', function() {
                     </tr>
                 `;
             });
-            
+
             tableHtml += `
                     </tbody>
                 </table>
             `;
-            
+
             historyContainer.innerHTML = tableHtml;
-            
+
             // Add event listeners to view notes buttons
             document.querySelectorAll('.view-notes-btn').forEach(btn => {
                 btn.addEventListener('click', function() {
                     const repairId = this.dataset.repairId;
                     currentRepairId = repairId;
                     loadRepairNotes(repairId);
-                    
+
                     // Switch to the notes tab
                     const notesTab = document.querySelector('#notes-tab');
                     notesTab.click();
@@ -421,12 +433,12 @@ document.addEventListener('DOMContentLoaded', function() {
             `;
         });
     }
-    
+
     // Function to load repair notes
     function loadRepairNotes(repairId) {
         const notesContainer = document.getElementById('repairNotesContent');
         if (!notesContainer) return;
-        
+
         notesContainer.innerHTML = `
             <div class="text-center">
                 <div class="spinner-border text-info" role="status">
@@ -434,7 +446,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 </div>
             </div>
         `;
-        
+
         // Fetch repair details including notes
         fetch(`/api/repairs/${repairId}/`, {
             headers: {
@@ -458,7 +470,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </div>
                     <div class="card-body">
             `;
-            
+
             // Resolution notes
             if (repair.resolution_notes) {
                 notesHtml += `
@@ -470,7 +482,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </div>
                 `;
             }
-            
+
             // All notes history
             if (repair.notes) {
                 notesHtml += `
@@ -478,7 +490,7 @@ document.addEventListener('DOMContentLoaded', function() {
                         <h5>Notes History</h5>
                         <div class="notes-timeline">
                 `;
-                
+
                 const notesList = repair.notes.split(';');
                 notesList.forEach(note => {
                     if (note.trim()) {
@@ -489,13 +501,13 @@ document.addEventListener('DOMContentLoaded', function() {
                         `;
                     }
                 });
-                
+
                 notesHtml += `
                         </div>
                     </div>
                 `;
             }
-            
+
             if (!repair.resolution_notes && !repair.notes) {
                 notesHtml += `
                     <div class="alert alert-info">
@@ -503,7 +515,7 @@ document.addEventListener('DOMContentLoaded', function() {
                     </div>
                 `;
             }
-            
+
             notesHtml += `
                     </div>
                 </div>
@@ -511,9 +523,9 @@ document.addEventListener('DOMContentLoaded', function() {
                     <i class="bi bi-arrow-left"></i> Back to Repair History
                 </button>
             `;
-            
+
             notesContainer.innerHTML = notesHtml;
-            
+
             // Add event listener to the back button
             const backToHistoryBtn = document.getElementById('backToHistoryBtn');
             if (backToHistoryBtn) {
@@ -534,12 +546,12 @@ document.addEventListener('DOMContentLoaded', function() {
             `;
         });
     }
-    
+
     // Helper function to get CSRF token
     function getCsrfToken() {
         return document.querySelector('[name=csrfmiddlewaretoken]').value;
     }
-    
+
     // Helper function to get status badge class
     function getStatusClass(status) {
         switch(status) {
@@ -549,7 +561,7 @@ document.addEventListener('DOMContentLoaded', function() {
             default: return 'secondary';
         }
     }
-    
+
     // Helper function to get repair status badge class
     function getRepairStatusClass(status) {
         switch(status.toLowerCase()) {
@@ -559,18 +571,18 @@ document.addEventListener('DOMContentLoaded', function() {
             default: return 'secondary';
         }
     }
-    
+
     // Helper function to get priority label
     function getPriorityLabel(priority) {
         if (priority >= 7) return '<span class="badge bg-danger">High</span>';
         if (priority >= 4) return '<span class="badge bg-warning text-dark">Medium</span>';
         return '<span class="badge bg-secondary">Low</span>';
     }
-    
+
     // Helper function to format date
     function formatDate(dateString) {
         if (!dateString) return '—';
         const date = new Date(dateString);
         return date.toLocaleDateString();
     }
-}); 
+});

--- a/machinery/templates/index.html
+++ b/machinery/templates/index.html
@@ -7,6 +7,5 @@
     <h1>Machines</h1>
     <p>MACHINES</p>
 
-<!-- TODO: add sections for model serial numbers, statuses (active, broken, repairing...) -->
 </body>
 </html>

--- a/repairs/templates/fault_form.html
+++ b/repairs/templates/fault_form.html
@@ -13,6 +13,8 @@
     <!-- Form for creating a fault -->
     <form method="post">
         {% csrf_token %}
+
+        <!-- Fault case form fields -->
         {% for field in form %}
             <div class="mb-3">
                 <label for="{{ field.id_for_label }}" class="form-label">{{ field.label }}</label>
@@ -26,10 +28,16 @@
             </div>
         {% endfor %}
 
+        <!-- Add note field -->
+        <div class="mb-3">
+            <label for="note" class="form-label">Fault Note</label>
+            <textarea class="form-control" id="note" name="note" rows="4" placeholder="Enter any additional notes"></textarea>
+        </div>
+
         <!-- Submit button -->
         <button type="submit" class="btn btn-primary">Submit Fault</button>
 
-        <!-- Back to Fault Case List button -->
+        <!-- Cancel button -->
         <a href="{% url 'repairs:fault_case_list' %}" class="btn btn-secondary">Cancel</a>
     </form>
 </div>

--- a/repairs/templates/warnings_form.html
+++ b/repairs/templates/warnings_form.html
@@ -1,0 +1,17 @@
+{% extends 'accounts/dashboard_base.html' %}
+
+{% block title %}Add Warning - Factory Machinery Tracking{% endblock %}
+
+{% block dashboard_title %}Add Warning{% endblock %}
+
+{% block dashboard_content %}
+    <h3>Add Warning for {{ machine.name }}</h3>
+    <form method="POST">
+        {% csrf_token %}
+        <div class="mb-3">
+            <label for="warning" class="form-label">Warning Message</label>
+            <textarea class="form-control" name="warning" rows="3" required></textarea>
+        </div>
+        <button type="submit" class="btn btn-warning">Submit Warning</button>
+    </form>
+{% endblock %}

--- a/repairs/urls.py
+++ b/repairs/urls.py
@@ -19,4 +19,5 @@ urlpatterns = [
     path('faults/create/', views.fault_case_create, name='fault_case_create'),
     path('faults/<uuid:fault_case_id>/update/', views.fault_case_update, name='fault_case_update'),
     path('faults/<uuid:fault_case_id>/fault_note_create/', views.fault_note_create, name='fault_note_create'),
+    # path('warnings/create/<int:machine_id>/', views.warning_form, name='warning_form'),
 ]

--- a/repairs/urls.py
+++ b/repairs/urls.py
@@ -18,6 +18,5 @@ urlpatterns = [
     path('faults/<uuid:fault_case_id>/', views.fault_case_detail, name='fault_case_detail'),
     path('faults/create/', views.fault_case_create, name='fault_case_create'),
     path('faults/<uuid:fault_case_id>/update/', views.fault_case_update, name='fault_case_update'),
-    path('faults/<uuid:fault_case_id>/fault_note_create/', views.fault_note_create, name='fault_note_create'),
-    # path('warnings/create/<int:machine_id>/', views.warning_form, name='warning_form'),
+    path('faults/<uuid:fault_case_id>/fault_note_create/', views.fault_note_create, name='fault_note_create')
 ]

--- a/repairs/views.py
+++ b/repairs/views.py
@@ -2,6 +2,8 @@ from django.shortcuts import render, get_object_or_404, redirect
 from django.contrib.auth.decorators import login_required
 from datetime import datetime
 from django.contrib import messages
+
+from machinery.models import Machinery
 from .models import FaultCase, FaultNote
 from .forms import FaultCaseForm, FaultNoteForm, FaultUpdateForm
 
@@ -33,36 +35,49 @@ def fault_case_detail(request, fault_case_id):
     notes = FaultNote.objects.filter(case=fault).order_by('-created_at') # Fetch all notes related to the fault case
     return render(request, 'fault_detail.html', {'fault_case': fault, 'notes': notes}) # Render the details of the fault case
 
+
 @login_required
 def fault_case_create(request):
     """
-    View to create a new fault case.
-    - Only technicians can create a fault case.
+    View to create a new fault case along with a note.
     - Handles both GET and POST requests.
-    - On GET, displays an empty form for creating a new fault case.
-    - On POST, validates the form data and saves the new fault case to the database. Redirects to the detail view of the newly created fault case.
-    - Passes the form to the 'fault_form.html' template for rendering.
+    - On POST, validates the form data and saves the new fault case and the fault note to the database.
     """
+    if not request.user.role == 'TECHNICIAN':  # Only technicians can create a fault case
+        return render(request, '403.html', status=403)  # Render a 403 Forbidden page
 
-    # TODO: add technician access
-    if not request.user.role == 'TECHNICIAN': # Check if the user is a technician
-        # If the user is not a technician, redirect to the fault case list page
-        return render(request, '403.html', status=403) # Render a 403 Forbidden page
-    
     if request.method == 'POST':
-        form = FaultCaseForm(request.POST) # Bind the submitted data to the form
+        form = FaultCaseForm(request.POST)  # Bind the submitted data to the form
+        note = request.POST.get('note')  # Get the note from the POST data
+
         # Validate the form data
         if form.is_valid():
-            fault = form.save(commit=False) # Create a new FaultCase instance but don't save it yet
-            fault.created_by = request.user # Set the user who created the fault case
-            fault.save() # Save the fault case to the database
+            fault = form.save(commit=False)  # Create a new FaultCase instance but don't save it yet
+            fault.created_by = request.user  # Set the user who created the fault case
+            fault.save()  # Save the fault case to the database
+
+            # Update the machine's status to 'FAULT' when a fault is created
+            machine = fault.machine  # Get the machine related to this fault case
+            machine.status = 'FAULT'
+            machine.save()
+
+            # Create a new FaultNote
+            if note:
+                # Use the correct field name here
+                FaultNote.objects.create(
+                    case=fault,  # 'case' instead of 'fault'
+                    user=request.user,
+                    note=note
+                )
 
             messages.success(request, f"Fault case #{fault.case_id} was successfully created.")
-            return redirect('accounts:technician_dashboard')
+            return redirect('accounts:technician_dashboard')  # Redirect back to the technician dashboard
     else:
-        form = FaultCaseForm() # Create an empty form for GET requests
+        form = FaultCaseForm()  # Create an empty form for GET requests
 
-    return render(request, 'fault_form.html', {'form': form}) # Render the form template
+    return render(request, 'fault_form.html', {'form': form})  # Render the form template
+
+
 
 @login_required
 def fault_case_update(request, fault_case_id):
@@ -108,3 +123,33 @@ def fault_note_create(request, fault_case_id):
     else:
         form = FaultNoteForm() # Create an empty form for GET requests
     return render(request, 'note_form.html', {'form': form, 'fault_case': fault}) # Render the form template for creating a new note
+
+# Add warnings (only Tech can do that)
+# @login_required
+# def warning_form(request, machine_id):
+#     # Get the machine for which the warning is being created
+#     machine = get_object_or_404(Machinery, machine_id=machine_id)
+#
+#     if request.method == 'POST':
+#         # Process the form submission
+#         message = request.POST.get('message')
+#
+#         # Create new warning object
+#         warning = Warning.objects.create(
+#             machine=machine,
+#             message=message,
+#             added_by=request.user,
+#             is_active=True
+#         )
+#
+#         # The Warning model's save method will automatically update the machine status
+#
+#         messages.success(request, f"Warning reported successfully for {machine.name}")
+#         return redirect('accounts:technician_dashboard')
+#
+#     # Render the warning form template
+#     context = {
+#         'machine': machine
+#     }
+#     return render(request, 'warnings_form.html', context)
+

--- a/repairs/views.py
+++ b/repairs/views.py
@@ -131,32 +131,3 @@ def fault_note_create(request, fault_case_id):
         form = FaultNoteForm() # Create an empty form for GET requests
     return render(request, 'note_form.html', {'form': form, 'fault_case': fault}) # Render the form template for creating a new note
 
-# Add warnings (only Tech can do that)
-# @login_required
-# def warning_form(request, machine_id):
-#     # Get the machine for which the warning is being created
-#     machine = get_object_or_404(Machinery, machine_id=machine_id)
-#
-#     if request.method == 'POST':
-#         # Process the form submission
-#         message = request.POST.get('message')
-#
-#         # Create new warning object
-#         warning = Warning.objects.create(
-#             machine=machine,
-#             message=message,
-#             added_by=request.user,
-#             is_active=True
-#         )
-#
-#         # The Warning model's save method will automatically update the machine status
-#
-#         messages.success(request, f"Warning reported successfully for {machine.name}")
-#         return redirect('accounts:technician_dashboard')
-#
-#     # Render the warning form template
-#     context = {
-#         'machine': machine
-#     }
-#     return render(request, 'warnings_form.html', context)
-


### PR DESCRIPTION
- Add ability for managers to assign repairmen (only technicians for now) => Manager Dashboard
- Managers need to have the ability to drill down and view summaries for different collections of machinery (dashboard)
- Add logic for technicians dashboard
- When "Technicians" accounts view their main dashboard view, they should first see the statuses of the machines they are assigned to, but if they want they can still view the other machines.
- Added ability for managers to create collections